### PR TITLE
A couple of things

### DIFF
--- a/xbmcswift2/mockxbmc/xbmcaddon.py
+++ b/xbmcswift2/mockxbmc/xbmcaddon.py
@@ -13,7 +13,7 @@ class Addon(object):
             'fanart', 'icon', 'id', 'name', 'path', 'profile', 'stars', 'summary',
             'type', 'version']
         assert id in properties, '%s is not a valid property.' % id
-        return True
+        return "unknown"
 
     def getLocalizedString(self, id):
         key = str(id)

--- a/xbmcswift2/mockxbmc/xbmcaddon.py
+++ b/xbmcswift2/mockxbmc/xbmcaddon.py
@@ -3,7 +3,7 @@ from xbmcswift2.logger import log
 
 
 class Addon(object):
-    def __init__(self, id):
+    def __init__(self, id=''):
         self._id = id
         self._strings = {}
         self._settings = {}

--- a/xbmcswift2/plugin.py
+++ b/xbmcswift2/plugin.py
@@ -234,6 +234,16 @@ class Plugin(XBMCMixin):
         pathqs = rule.make_path_qs(items)
         return 'plugin://%s%s' % (self._addon_id, pathqs)
 
+    def route_for(self, path):
+        '''Returns the view function for given path, None if no route exist'''
+        for rule in self._routes:
+            try:
+                view_func, items = rule.match(path)
+            except NotFoundException:
+                continue
+            return view_func
+        return None
+
     def _dispatch(self, path):
         for rule in self._routes:
             try:

--- a/xbmcswift2/plugin.py
+++ b/xbmcswift2/plugin.py
@@ -10,6 +10,7 @@
 '''
 import os
 import sys
+import __main__
 import pickle
 import xbmcswift2
 from urllib import urlencode
@@ -49,7 +50,7 @@ class Plugin(XBMCMixin):
                      builtin ``__file__`` variable can used.
     '''
 
-    def __init__(self, name, addon_id, filepath):
+    def __init__(self, name, addon_id, filepath=__main__.__file__):
         self._name = name
         self._filepath = filepath
         self._addon_id = addon_id

--- a/xbmcswift2/plugin.py
+++ b/xbmcswift2/plugin.py
@@ -50,13 +50,16 @@ class Plugin(XBMCMixin):
                      builtin ``__file__`` variable can used.
     '''
 
-    def __init__(self, name, addon_id, filepath=__main__.__file__):
-        self._name = name
+    def __init__(self, name='', addon_id='', filepath=__main__.__file__):
+        if addon_id:
+            self._addon = xbmcaddon.Addon(id=addon_id)
+        else:
+            self._addon = xbmcaddon.Addon()
+        self._addon_id = addon_id or self.addon.getAddonInfo('id')
+        self._name = name or self._addon.getAddonInfo('name')
         self._filepath = filepath
-        self._addon_id = addon_id
         self._routes = []
         self._view_functions = {}
-        self._addon = xbmcaddon.Addon(id=self._addon_id)
 
         # Keeps track of the added list items
         self._current_items = []


### PR DESCRIPTION
1. Added defaults for the `Plugin`  constructor. I don't see why anybody would need to override these, but I left them for backwards comparability..
2. Added a `route_for` method to determine where an url routes. A use-case for this can be seen here: https://github.com/takoi/xbmc-addon-nrk/blob/master/default.py#L63 Basically, it replaces the entire playable-or-directory logic by using route_for to find out whether it routes to the play node or not.
