### PR TITLE
Use the much faster cPickle module instead of pickle for storage

### DIFF
--- a/xbmcswift2/storage.py
+++ b/xbmcswift2/storage.py
@@ -11,7 +11,7 @@ import os
 import csv
 import json
 import time
-import pickle
+import cPickle as pickle
 import shutil
 import collections
 from datetime import datetime


### PR DESCRIPTION
I'd like to use the cached decorator, but it is quite slow on atv2.
Using cPickle makes quite a difference on platforms like atv2 or rpi.

Using cPickle in common.py seems to break the pickle_dict / unpickle_dict functions (I didn't really check why). But it should be safe in storage.py.
It would probably be good to use cPickle in common.py as well.
