### PR TITLE
Can call cli directly from python on command line

### DIFF
--- a/xbmcswift2/cli/cli.py
+++ b/xbmcswift2/cli/cli.py
@@ -74,3 +74,6 @@ def main():
     # Since we are calling a specific comamnd's manager, we no longer need the
     # actual command in sys.argv so we slice from position 1
     manager.run(opts, args[1:])
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This allows me to run the plugin using the CLI by CDing into the plugin directory and then running:

```
PYTHONPATH=~/workspace/xbmcswift2/:$PYTHONPATH python ~/workspace/xbmcswift2/xbmcswift2/cli/cli.py run interactive
```
