### PR TITLE
added optional conversion of value in get_setting()

### DIFF
--- a/tests/test_xbmcmixin.py
+++ b/tests/test_xbmcmixin.py
@@ -65,6 +65,26 @@ class TestXBMCMixin(TestCase):
     def test_get_setting(self):
         self.m.get_setting('username')
         assert self.m.addon.getSetting.called_with(id='username')
+        # Test int
+        self.m.addon.getSetting.return_value = '3'
+        self.assertEqual(self.m.get_setting('int'), '3')
+        self.assertEqual(self.m.get_setting('int', int), 3)
+        # Test bool
+        self.m.addon.getSetting.return_value = 'true'
+        self.assertEqual(self.m.get_setting('bool'), 'true')
+        self.assertEqual(self.m.get_setting('bool', bool), True)
+        self.m.addon.getSetting.return_value = 'false'
+        self.assertEqual(self.m.get_setting('bool'), 'false')
+        self.assertEqual(self.m.get_setting('bool', bool), False)
+        # Test unicode
+        self.m.addon.getSetting.return_value = 'd\xc3\xb6ner'
+        self.assertEqual(self.m.get_setting('unicode'), 'd\xc3\xb6ner')
+        self.assertEqual(self.m.get_setting('unicode', unicode), u'd\xf6ner')
+        # Test list
+        self.m.addon.getSetting.return_value = '2'
+        lst = ('1', 2, True, False)
+        self.assertEqual(self.m.get_setting('list'), '2')
+        self.assertEqual(self.m.get_setting('list', choices=lst), lst[2])
 
     def test_set_setting(self):
         self.m.set_setting('username', 'xbmc')

--- a/xbmcswift2/xbmcmixin.py
+++ b/xbmcswift2/xbmcmixin.py
@@ -143,10 +143,46 @@ class XBMCMixin(object):
         #assert content in contents, 'Content type "%s" is not valid' % content
         xbmcplugin.setContent(self.handle, content)
 
-    def get_setting(self, key):
+    def get_setting(self, key, converter=None, choices=None):
+        '''Returns the settings value for the provided key.
+        If converter is str, unicode, bool or int the settings value will be
+        returned converted to the provided type.
+        If choices is an instance of list or tuple its item at position of the
+        settings value be returned.
+        .. note:: It is suggested to always use unicode for text-settings
+                  because else xbmc returns utf-8 encoded strings.
+
+        :param key: The id of the setting defined in settings.xml.
+        :param converter: (Optional) Choices are str, unicode, bool and int.
+        :param converter: (Optional) Choices are instances of list or tuple.
+
+        Examples: 
+            * ``plugin.get_setting('per_page', int)``
+            * ``plugin.get_setting('password', unicode)``
+            * ``plugin.get_setting('force_viewmode', bool)``
+            * ``plugin.get_setting('content', choices=('videos', 'movies'))``
+        '''
         #TODO: allow pickling of settings items?
         # TODO: STUB THIS OUT ON CLI
-        return self.addon.getSetting(id=key)
+        value = self.addon.getSetting(id=key)
+        if converter is str:
+            return value
+        elif converter is unicode:
+            return value.decode('utf-8')
+        elif converter is bool:
+            return value == 'true'
+        elif converter is int:
+            return int(value)
+        elif isinstance(choices, (list, tuple)):
+            return choices[int(value)]
+        elif converter is None:
+            log.warning('No converter provided, unicode should be used, '
+                        'but returning str value')
+            return value
+        else:
+            raise TypeError('Acceptable converters are str, unicode, bool and '
+                            'int. Acceptable choices are instances of list '
+                            ' or tuple.')
 
     def set_setting(self, key, val):
         # TODO: STUB THIS OUT ON CLI


### PR DESCRIPTION
Example bool:

``` xml
<!-- addon_dir/resources/settings.xml -->
<setting id="test" type="bool" /> 

<!-- addon_data/settings.xml -->
<setting id="test" value="true" /> 
```

``` python
>>> print repr(plugin.get_setting('test'))
'true'
>>> print repr(plugin.get_setting('test', bool))
True
```

Example enum:

``` xml
<!-- addon_dir/resources/language/English/strings.xml -->
<string id="30110">Resolution</string>  
<string id="30111">480p</string>
<string id="30112">720p</string>
<string id="30113">1080p</string>

<!-- addon_dir/resources/settings.xml -->
<setting id="resolution" type="enum" label="30110" default="1" lvalues="30111|30112|30113"/>

<!-- addon_data/settings.xml -->
<setting id="resolution" value="2" />
```

``` python
>>> print repr(plugin.get_setting('resolution'))
'2'
>>> resolutions = ('480',  '720', '1080')
>>> print repr(plugin.get_setting('resolution', choices=resolutions))
'1080'
```

Of course the same with int and unicode.

regards,
sphere
