### PR TITLE
function arg could be empty string, the matching rule regex updated.

### DIFF
--- a/xbmcswift2/urls.py
+++ b/xbmcswift2/urls.py
@@ -50,7 +50,7 @@ class UrlRule(object):
         self._url_format = self._url_rule.replace('<', '{').replace('>', '}')
 
         # Make a regex pattern for matching incoming URLs
-        p = self._url_rule.replace('<', '(?P<').replace('>', '>[^/]+?)')
+        p = self._url_rule.replace('<', '(?P<').replace('>', '>[^/]*?)')
 
         try:
             self._regex = re.compile('^' + p + '$')


### PR DESCRIPTION
sometimes, like an optional search keyboard, could be an empty string in the url like /<key>/ will result '//', which could not be corrected parsed. this commit will fix it.
