### PR TITLE
add string cache in get_string()

### DIFF
--- a/tests/test_xbmcmixin.py
+++ b/tests/test_xbmcmixin.py
@@ -55,6 +55,10 @@ class TestXBMCMixin(TestCase):
     def test_get_string(self):
         self.m.addon.getLocalizedString.return_value = 'Hello XBMC'
         self.assertEqual('Hello XBMC', self.m.get_string('30000'))
+        # check if the string comes from cache
+        self.m.addon.getLocalizedString.return_value = ''
+        self.assertEqual('Hello XBMC', self.m.get_string('30000'))
+        # check if retrieval by int and str returns same (and comes from cache)
         self.assertEqual('Hello XBMC', self.m.get_string(30000))
 
     @patch('xbmcswift2.xbmcplugin')

--- a/xbmcswift2/xbmcmixin.py
+++ b/xbmcswift2/xbmcmixin.py
@@ -131,7 +131,12 @@ class XBMCMixin(object):
         '''Returns the localized string from strings.xml for the given
         stringid.
         '''
-        return self.addon.getLocalizedString(stringid)
+        stringid = int(stringid)
+        if not hasattr(self, '_strings'):
+            self._strings = {}
+        if not stringid in self._strings:
+            self._strings[stringid] = self.addon.getLocalizedString(stringid)
+        return self._strings[stringid]
 
     def set_content(self, content):
         '''Sets the content type for the plugin.'''


### PR DESCRIPTION
Implemented a simple dict-based cache in the get_string()-method.
Not sure if it has any noticeable speed improvement but retrieving a string in a for loop feels wrong and retrieving (multiple) strings before the loop in the add-on code looks ugly.

Example usage where it could have a speed improvement: https://github.com/dersphere/plugin.video.itunes_podcasts/blob/master/addon.py#L172
