### PR TITLE
simple the current set_resolved_url method in develop branch

### DIFF
--- a/xbmcswift2/xbmcmixin.py
+++ b/xbmcswift2/xbmcmixin.py
@@ -281,25 +281,24 @@ class XBMCMixin(object):
             item = xbmcswift2.ListItem.from_dict(**item)
         return item
 
-    def set_resolved_url(self, url=None, item=None):
+    def set_resolved_url(self, item=None):
         '''Takes a url or a listitem to be played. Used in conjunction with a
         playable list item with a path that calls back into your addon.
 
         :param url:
                     .. deprecated:: 0.3.0
                     Use `item` instead. A playable URL.
-        :param item: A playable list item.
+        :param item: A playable list item or url.
+                     None item will tell xbmc the resolve failed.
         '''
-        if url:
-            log.warning('The "url" param has been deprecated. Please use the '
-                        '"item" param instead.')
+        if item is None:
+            # None item/url indicates the resolve url failed.
+            xbmcplugin.setResolvedUrl(self.handle, False, xbmcswift2.ListItem().as_xbmc_listitem())
+            return
 
-        if url is None and item is None:
-            raise ValueError('Either url or item must have a non-None value.')
-
-        # if a url was provided, ignore any value passed for item
-        if url:
-            item = {'path': url}
+        if isinstance(item, basestring):
+            # caller set the resolved url without argument keyword
+            item = {'path': item}
 
         item = self._listitemify(item)
         item.set_played(True)


### PR DESCRIPTION
since the original method has only one param, no developer will call it with the keyword 'url'.
we can make the method more simple and do not produce warning for existed code.

also None item should call setResolvedUrl with succeeded=False, which will tell xbmc the resolve failed.

supply a way to tell xbmc resolve failed is useful since the setResolvedUrl supplies the fail route, if set_resolve_url do not supply this usage, developer had to use the setResolvedUrl directly, then it should not be good since the set_resolve_url was intent to wrap setResolvedUrl.
