### PR TITLE
added method for setting stream infos

### DIFF
--- a/tests/test_listitem.py
+++ b/tests/test_listitem.py
@@ -83,6 +83,14 @@ class TestListItem(TestCase):
             item.set_info('video', {'title': '300'})
         mock_setInfo.assert_called_with('video', {'title': '300'})
 
+    def test_stream_info(self):
+        with patch.object(xbmcgui.ListItem, 'addStreamInfo') as mock_stream_info:
+            item = ListItem()
+            item.add_stream_info('video', {'duration': 185})
+            mock_stream_info.assert_called_with('video', {'duration': 185})
+            item.add_stream_info('audio', {'languange': 'en'})
+            mock_stream_info.assert_called_with('audio', {'languange': 'en'})
+
     def test_selected(self):
         item = ListItem()
         self.assertEqual(item.selected, False)
@@ -171,10 +179,14 @@ class TestFromDict(TestCase):
             'info': {'title': 'My title'},
             'info_type': 'pictures',
             'properties': [('StartOffset', '256.4')],
+            'stream_info': {
+                'video': {'duration': 185}
+            },
             'context_menu': [('label', 'action')],
             'is_playable': True}
         with patch.object(ListItem, 'set_info', spec=True) as mock_set_info:
-            item = ListItem.from_dict(**dct)
+            with patch.object(ListItem, 'add_stream_info', spec=True) as mock_set_stream_info:
+                item = ListItem.from_dict(**dct)
         self.assertEqual(item.label, 'foo')
         self.assertEqual(item.label2, 'bar')
         self.assertEqual(item.icon, 'icon')
@@ -182,6 +194,7 @@ class TestFromDict(TestCase):
         self.assertEqual(item.path, 'plugin://my.plugin.id/')
         self.assertEqual(item.selected, True)
         mock_set_info.assert_called_with('pictures', {'title': 'My title'})
+        mock_set_stream_info.assert_called_with('video', {'duration': 185})
         self.assertEqual(item.get_property('StartOffset'), '256.4')
         self.assertEqual(item.get_context_menu_items(), [('label', 'action')]) 
         self.assertEqual(item.get_property('isPlayable'), 'true')

--- a/xbmcswift2/listitem.py
+++ b/xbmcswift2/listitem.py
@@ -108,6 +108,10 @@ class ListItem(object):
         '''Sets a property for the given key and value'''
         return self._listitem.setProperty(key, value)
 
+    def add_stream_info(self, stream_type, stream_values):
+        '''Adds stream details'''
+        return self._listitem.addStreamInfo(stream_type, stream_values)
+
     def get_icon(self):
         '''Returns the listitem's icon image'''
         return self._icon
@@ -182,7 +186,7 @@ class ListItem(object):
     def from_dict(cls, label=None, label2=None, icon=None, thumbnail=None,
                   path=None, selected=None, info=None, properties=None,
                   context_menu=None, replace_context_menu=False,
-                  is_playable=None, info_type='video'):
+                  is_playable=None, info_type='video', stream_info=None):
         '''A ListItem constructor for setting a lot of properties not
         available in the regular __init__ method. Useful to collect all
         the properties in a dict and then use the **dct to call this
@@ -202,6 +206,13 @@ class ListItem(object):
         if properties:
             for key, val in properties:
                 listitem.set_property(key, val)
+
+        if stream_info:
+            assert isinstance(stream_info, dict)
+            for stream_type in ('video', 'audio', 'subtitle'):
+                if stream_type in stream_info:
+                    stream_values = stream_info[stream_type]
+                    listitem.add_stream_info(stream_type, stream_values)
 
         if context_menu:
             listitem.add_context_menu_items(context_menu, replace_context_menu)

--- a/xbmcswift2/mockxbmc/xbmcgui.py
+++ b/xbmcswift2/mockxbmc/xbmcgui.py
@@ -6,6 +6,7 @@ class ListItem(object):
         self.thumbnailImage = thumbnailImage
         self.path = path
         self.properties = {}
+        self.stream_info = {}
         self.selected = False
         self.infolabels = {}
 
@@ -45,6 +46,9 @@ class ListItem(object):
 
     def setProperty(self, key, value):
         self.properties[key.lower()] = value
+
+    def addStreamInfo(self, stream_type, stream_values):
+        self.stream_info.update({stream_type: stream_values})
 
     def setThumbnailImage(self, thumb):
         self.thumbnailImage = thumb


### PR DESCRIPTION
On Frodo the infolabel "duration" does not work like on Eden.
On Eden it assumes string of "mm:ss", with Frodo this was changed.

Frodo prints following warning to xbmc.log:
`WARNING: GetDurationFromMinuteString <runtime> should be in minutes. Interpreting '2:06' as 2 minutes`
While showing only the minute part ("2:00") or even hides the duration if minute is 0 (like with "0:45").

This issue is discussed here: http://forum.xbmc.org/showthread.php?tid=146794 With the suggestion of using:

``` python
list_item.addStreamInfo('video', {'duration': 126})
```

to show the duration like "2:06". XBMC method description here: http://mirrors.xbmc.org/docs/python-docs/xbmcgui.html#ListItem-addStreamInfo

This was not possible with xbmcswift2 so I added `ListItem.add_stream_info(stream_type, stream_values)`and changed `ListItem.from_dict()` to accept it via auto creation. I also added the needed test cases.

Example Usage via implicit ListItem.from_dict():

``` python
@plugin.route('/')
def show_demo_entry():
    item = {
        'label': 'Test Video',
        'thumbnail': 'foo.png',
        'is_playable': True,
        'info': {
            'plot': 'foo baar',
        },
        'stream_info': {
            'video': {'duration': 185, 'width' : 1280},
            'audio': {'language': 'en'},
        },
        'path': plugin.url_for('play_video')},
    }
    return plugin.finish([item])
```
