### PR TITLE
added automatic url_rule generation in route()-decorator

### DIFF
--- a/xbmcswift2/plugin.py
+++ b/xbmcswift2/plugin.py
@@ -8,6 +8,7 @@
     :copyright: (c) 2012 by Jonathan Beluch
     :license: GPLv3, see LICENSE for more details.
 '''
+from inspect import getargspec
 import os
 import sys
 import pickle
@@ -237,13 +238,22 @@ class Plugin(XBMCMixin):
             return route_decorator(cache_decorator(func))
         return new_decorator
 
-    def route(self, url_rule, name=None, options=None):
+    def route(self, url_rule=None, name=None, is_root=False, options=None):
         '''A decorator to add a route to a view. name is used to
         differentiate when there are multiple routes for a given view.'''
         # TODO: change options kwarg to defaults
         def decorator(f):
             view_name = name or f.__name__
-            self.add_url_rule(url_rule, f, name=view_name, options=options)
+            if is_root:
+                _url_rule = '/'
+            elif not url_rule:
+                _url_rule = '/%s/' % view_name
+                args = getargspec(f)[0]
+                if args:
+                    _url_rule += '/'.join('%s/<%s>' % (p, p) for p in args)
+            else:
+                _url_rule = url_rule
+            self.add_url_rule(_url_rule, f, name=view_name, options=options)
             return f
         return decorator
 


### PR DESCRIPTION
I'm not sure if this is something you/we really want, so I only updated the code. If you like it, I can add tests and update the docs.

With this change the following is possible:

``` python
@plugin.route(is_root=True)
def root():
    items = [
        {'label': 'Latest',
         'path': plugin.url_for('show_movies')},
    ]
    return plugin.finish(items)

@plugin.route()
def show_movies():
    items = [{
        'label': movie['title'],
        'is_playable': True,
        'path': plugin.url_for(
            endpoint='play_movie',
            movie_id=movie['id']
        )
    } for movie in get_movies()]
    return plugin.finish(items)

@plugin.route()
def func_with_much_params(foo, bar, lorem, ipsum):
    pass

@plugin.route()
def play_movie(movie_id):
    url = get_url(movie_id)
    return plugin.set_resolved_url(url)
```

The URLs from the above example will be:

```
'/'
'/show_movies'
'/func_with_much_params/foo/<foo>/bar/<bar>/lorem/<lorem>/ipsum/<ipsum>'
'/play_movie/movie_id/<movie_id>'
```

It could also be changed to _not_ add the param name, example:

```
'/'
'/show_movies'
'/func_with_much_params/<foo>/<bar>/<lorem>/<ipsum>'
'/play_movie/<movie_id>'
```

This change should be fully backward compatible.
Personally I prefer defining the routes myself but while in development it saves some time. ;-)
