### PR TITLE
title and message in notify

### DIFF
--- a/tests/test_xbmcmixin.py
+++ b/tests/test_xbmcmixin.py
@@ -195,7 +195,7 @@ class TestXBMCMixin(TestCase):
         with patch.object(plugin.addon, 'getAddonInfo', return_value='Academic Earth') as mockGetAddonInfo:
             plugin.notify('Hello World!')
         mockExecutebuiltin.assert_called_with(
-            'XBMC.Notification("Hello World!", "Academic Earth", "5000", "")'
+            'XBMC.Notification("Academic Earth", "Hello World!", "5000", "")'
         )
 
     @patch('xbmcswift2.xbmc.executebuiltin')
@@ -204,7 +204,7 @@ class TestXBMCMixin(TestCase):
         with patch.object(plugin.addon, 'getAddonInfo', return_value='Academic Earth') as mockGetAddonInfo:
             plugin.notify('Hello World!', 'My Title', 3000, 'http://example.com/image.png')
         mockExecutebuiltin.assert_called_with(
-                'XBMC.Notification("Hello World!", "My Title", "3000", "http://example.com/image.png")'
+                'XBMC.Notification("My Title", "Hello World!", "3000", "http://example.com/image.png")'
         )
 
     @patch('xbmcswift2.xbmc.Keyboard')

--- a/xbmcswift2/xbmcmixin.py
+++ b/xbmcswift2/xbmcmixin.py
@@ -296,8 +296,9 @@ class XBMCMixin(object):
             log.warning('Empty message for notification dialog')
         if title is None:
             title = self.addon.getAddonInfo('name')
-        xbmc.executebuiltin('XBMC.Notification("%s", "%s", "%s", "%s")' %
-                            (msg, title, delay, image))
+        cmd = 'XBMC.Notification("{header}", "{message}", "{time}", "{image}")'.format(
+            header=title, message=msg, time=delay, image=image)
+        xbmc.executebuiltin(cmd)
 
     def _listitemify(self, item):
         '''Creates an xbmcswift2.ListItem if the provided value for item is a


### PR DESCRIPTION
Why `msg` before `title` in https://github.com/jbeluch/xbmcswift2/blob/master/xbmcswift2/xbmcmixin.py#L299 ?
In XBMC wiki `header` before `msg` http://wiki.xbmc.org/index.php?title=List_of_built-in_functions
