### PR TITLE
fix xbmcvfs import error on non cli mode

### DIFF
--- a/xbmcswift2/__init__.py
+++ b/xbmcswift2/__init__.py
@@ -46,6 +46,7 @@ try:
     import xbmcgui
     import xbmcplugin
     import xbmcaddon
+    import xbmcvfs
     CLI_MODE = False
 except ImportError:
     CLI_MODE = True


### PR DESCRIPTION
commit db3efe4b86e199de35c335ec596692d35d53cb99 does not fix issue #58 on "real mode" - only on cli mode.
