### PR TITLE
add matching view name and its args back to plugin.request

### DIFF
--- a/xbmcswift2/plugin.py
+++ b/xbmcswift2/plugin.py
@@ -301,8 +301,10 @@ class Plugin(XBMCMixin):
                 view_func, items = rule.match(path)
             except NotFoundException:
                 continue
+            self._request.view = view_func.__name__
+            self._request.view_params = items
             log.info('Request for "%s" matches rule for function "%s"',
-                     path, view_func.__name__)
+                     path, self._request.view)
             listitems = view_func(**items)
 
             # Only call self.finish() for UI container listing calls to plugin


### PR DESCRIPTION
This is more a draft/idea than a full PR.

Problem is, when you have a view with multiple URLs but want to add pagination you need to know the actual views function name and params.

Example code to show the problem:

``` python
@plugin.route('/videos/<page>/')
def show_videos(page):
    items = api.get_videos(page)
    items.append({
        'label': '>> Next Page >>',
        'path': plugin.url_for(
            'show_videos',
            page=(int(page) + 1)
        )
    })
    return items

@plugin.route('/videos/<artist>/<page>/')
def show_videos_by_artist(page, artist):
    items = api.get_videos(artist, page)
    items.append({
        'label': '>> Next Page >>',
        'path': plugin.url_for(
            'show_videos_by_artist',
            page=(int(page) + 1),
            artist=artist
        )
    })
    return items
```

The views can't be merged to one "multi route view" because the next-page-endpoint is unknown (also it is unknown if the endpoint requires one of the optional kwargs).
Of course in this simple example the code redundancy would not matter, but there are much more complex examples possible. Think about a view which has multiple content altering parameters like "sort_by, sort_order, artist_id, page, ...".

With the change in this PR the views can be merged because the current view (its function name) and its current param-dict is available (for in place patching):

``` python
@plugin.route('/videos/<page>/')
@plugin.route('/videos/<artist>/<page>/', name='show_videos_by_artist')
def show_videos(page, artist=None):
    items = api.get_videos(artist, page)
    items.append({
        'label': '>> Next Page >>',
        'path': plugin.url_for(
            plugin.request.view
            **dict(plugin.request.view_args, page=int(page) + 1)
        )
    })
    return items
```
