### PR TITLE
Update patterns.rst

### DIFF
--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -220,7 +220,7 @@ Here is a quick example of updating the context menu.
     from xbmcswift2 import actions
 
     @plugin.url('/favorites/add/<url>')
-    def add_to_favs(url):
+    def add_to_favorites(url):
         # this is a background view
         ...
 


### PR DESCRIPTION
in the context menu example the url_for function was pointing to a non existing function.
