### PR TITLE
Override self.request with the new request when redirecting

### DIFF
--- a/xbmcswift2/plugin.py
+++ b/xbmcswift2/plugin.py
@@ -320,10 +320,10 @@ class Plugin(XBMCMixin):
     def redirect(self, url):
         '''Used when you need to redirect to another view, and you only
         have the final plugin:// url.'''
-        # TODO: Should we be overriding self.request with the new request?
-        new_request = self._parse_request(url=url, handle=self.request.handle)
-        log.debug('Redirecting %s to %s', self.request.path, new_request.path)
-        return self._dispatch(new_request.path)
+        original_request = self.request
+        self._request = self._parse_request(url=url, handle=original_request.handle)
+        log.debug('Redirecting %s to %s', original_request.path, self.request.path)
+        return self._dispatch(self.request.path)
 
     def run(self, test=False):
         '''The main entry point for a plugin.'''


### PR DESCRIPTION
This PR overrides `self._request` in the Plugin when using Plugin.redirect. This fixes a bug where when the request is redirected, although the new path will be invoked, the plugin.request value will be the original request and all query parameters from the redirect will not be set.

/cc @jbeluch
